### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/atlestroms0321/bcb96420-5f60-4845-ad1f-ca9bc1394777/d1d11b62-ba4e-4ee5-adb7-29c01edb6034/_apis/work/boardbadge/c443da14-8efa-424c-ae0a-dfc27c9f37ed)](https://dev.azure.com/atlestroms0321/bcb96420-5f60-4845-ad1f-ca9bc1394777/_boards/board/t/d1d11b62-ba4e-4ee5-adb7-29c01edb6034/Microsoft.RequirementCategory)
 # gitlab-mr-notice-vscode
 
 This is a reminder widget for gitlab merge requests


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/atlestroms0321/bcb96420-5f60-4845-ad1f-ca9bc1394777/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.